### PR TITLE
Add share feature and fix pair display

### DIFF
--- a/Result.html
+++ b/Result.html
@@ -35,15 +35,12 @@
       margin: 0.5rem 0;
       text-align: left;
     }
-    .character-info {
-      margin-top: 1rem;
-      display: flex;
-      justify-content: center;
-    }
     #character-img {
       max-width: 220px;
       border-radius: 8px;
       box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+      display: block;
+      margin: 0 auto 1rem;
     }
     .toolkit-download {
       margin-top: 2rem;
@@ -57,6 +54,19 @@
       text-decoration: none;
       border-radius: 6px;
     }
+    .pair {
+      background: #fff;
+      margin: 1rem auto;
+      padding: 1rem;
+      border-radius: 8px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+      max-width: 500px;
+      display: none;
+    }
+    .pair .tagline {
+      font-style: italic;
+      color: #555;
+    }
   </style>
 </head>
 <body>
@@ -64,13 +74,11 @@
   <div class="summary">
     <h2 id="result-title"></h2>
     <p id="result-desc"></p>
-    <p id="result-role"></p>
-    <div class="character-info">
-      <img id="character-img" src="" alt="">
-    </div>
   </div>
   <div class="result-container">
     <div class="text-info">
+      <p id="result-role"></p>
+      <img id="character-img" src="" alt="">
       <h3 id="role-name"></h3>
       <p id="role-series"></p>
       <p id="role-trait"></p>
@@ -78,11 +86,29 @@
       <p id="role-tip"></p>
     </div>
   </div>
-  <div class="character-info">
-    <img id="character-img" src="" alt="">
-  </div>
   <script>
-  const RESULTS = {
+  let picked = '';
+
+  function shareResult() {
+    const text = '我的角色互補配對是 ' + picked;
+    const data = { title: '人生航行角色配對', text, url: location.href };
+    if (navigator.share) {
+      navigator.share(data).catch(() => {
+        alert('分享失敗，請截圖分享');
+      });
+    } else {
+      const input = document.createElement('input');
+      input.value = text + ' ' + location.href;
+      document.body.appendChild(input);
+      input.select();
+      document.execCommand('copy');
+      document.body.removeChild(input);
+      alert('已複製到剪貼簿，快貼給朋友吧！');
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const RESULTS = {
       "A1B1": {title:"起霧的小艇",desc:"剛覺醒但環境混亂，內外皆不明，正需要找到個人定位",role:"小叉型、榮恩型"},
       "A1B2": {title:"混水試航者",desc:"起點就遇挑戰，激起你尋找自我與避風港的渴望",role:"安娜型、喬巴型"},
       "A1B3": {title:"初風起帆者",desc:"環境支持你出發，內心雖迷茫但正是好奇探索的最佳時刻",role:"魯夫型、奧拉夫型"},
@@ -143,7 +169,7 @@
       document.getElementById('result-desc').textContent = result.desc;
       const roles = result.role.split('、');
       const second = new Date().getSeconds();
-      const picked = (second % 2 === 1) ? roles[0] : roles[1];
+      picked = (second % 2 === 1) ? roles[0] : roles[1];
       const info = CHARACTERS[picked] || {};
       document.getElementById('result-role').textContent = '推薦角色：' + picked;
       document.getElementById('role-name').textContent = picked;
@@ -159,10 +185,79 @@
     } else {
       document.getElementById('result-title').textContent = '無法判斷結果';
     }
+
+    document.querySelectorAll('.pair').forEach(el => {
+      const roles = (el.dataset.roles || '').split(',');
+      if (roles.includes(picked)) {
+        el.style.display = 'block';
+      }
+    });
+  });
   </script>
   <div class="toolkit-download">
       <a href="LifeSailingToolkit.pdf" class="download-btn" download>下載人生航行模型工具包</a>
       <p>拿一份專屬工具包，幫你找到下一步方向，不再迷航！</p>
+  </div>
+
+  <h1>人生航行｜你的角色互補配對是？</h1>
+  <div id="pairings">
+    <div class="pair" data-roles="索隆型,妙麗型" id="pair-zoro-hermione">
+      <h2>索隆型 × 妙麗型</h2>
+      <p>索隆堅定執行但易卡關，妙麗規劃力強能解構路線。</p>
+      <p class="tagline">策略與行動並肩，讓意志不再孤軍作戰。</p>
+    </div>
+
+    <div class="pair" data-roles="喬巴型,克斯托夫型" id="pair-chopper-kristoff">
+      <h2>喬巴型 × 克斯托夫型</h2>
+      <p>照顧者與港灣的相遇，彼此照應、不再耗竭。</p>
+      <p class="tagline">彼此是港灣，也為彼此補給。</p>
+    </div>
+
+    <div class="pair" data-roles="魯夫型,妙麗型" id="pair-luffy-hermione">
+      <h2>魯夫型 × 妙麗型</h2>
+      <p>熱血與理性攜手，讓衝勁有了方向。</p>
+      <p class="tagline">熱血需要方向，理性需要推動。</p>
+    </div>
+
+    <div class="pair" data-roles="艾莎型,巴斯型" id="pair-elsa-buzz">
+      <h2>艾莎型 × 巴斯型</h2>
+      <p>冰封的自我與轉變的勇氣交會。</p>
+      <p class="tagline">轉變不是拋下，而是解凍的開始。</p>
+    </div>
+
+    <div class="pair" data-roles="安娜型,韓索羅型" id="pair-anna-hansolo">
+      <h2>安娜型 × 韓索羅型</h2>
+      <p>熱情付出與渴望靠近的靈魂共鳴。</p>
+      <p class="tagline">為愛靠近，不需先完美。</p>
+    </div>
+
+    <div class="pair" data-roles="哈利型,露娜型" id="pair-harry-luna">
+      <h2>哈利型 × 露娜型</h2>
+      <p>責任與真我交會，在理解中航行。</p>
+      <p class="tagline">忠於內在，也勇敢選擇責任。</p>
+    </div>
+
+    <div class="pair" data-roles="榮恩型,小叉型" id="pair-ron-forky">
+      <h2>榮恩型 × 小叉型</h2>
+      <p>共同走出陰影，探索屬於自己的光芒。</p>
+      <p class="tagline">我們都不是配角，而是同行者。</p>
+    </div>
+
+    <div class="pair" data-roles="翠絲型,奧拉夫型" id="pair-jessie-olaf">
+      <h2>翠絲型 × 奧拉夫型</h2>
+      <p>故事與幽默的療癒之旅，從心開始。</p>
+      <p class="tagline">故事可以重寫，笑容也能療癒。</p>
+    </div>
+
+    <div class="pair" data-roles="黛西型" id="pair-daisy">
+      <h2>單飛型角色：黛西型</h2>
+      <p>你是新時代的開端，也能選擇與誰啟航。</p>
+      <p class="tagline">選擇你的共航者，展開屬於你的故事。</p>
+    </div>
+  </div>
+
+  <div class="cta">
+    <button onclick="shareResult()">🔗 分享我的航行配對</button>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap result logic in DOMContentLoaded so complementary pair sections show
- implement `shareResult()` using Web Share API with clipboard fallback
- hook share button to new function
- combine role details and image inside one result card

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68425e659e64832a964bd5e2db85a556